### PR TITLE
Fixed tracking stars from the telescope and world hopping not working

### DIFF
--- a/src/main/java/com/shootingstartracking/WorldHop.java
+++ b/src/main/java/com/shootingstartracking/WorldHop.java
@@ -4,7 +4,7 @@ import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
-import net.runelite.api.widgets.InterfaceID;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatMessageBuilder;
@@ -83,7 +83,7 @@ public class WorldHop
 			return;
 		}
 
-		if (client.getWidget(InterfaceID.WORLD_SWITCHER) == null)
+		if (client.getWidget(InterfaceID.WORLDSWITCHER, 0) == null)
 		{
 			client.openWorldHopper();
 


### PR DESCRIPTION
The child of the telescope widget changed so that's why it wasn't working.
I have changed the logic to use the `ChatMessage` event instead of manually extracting the text for possible more stable updates.
Fixes #12

The `getWidget` without a child is for getting with a `componentId`, added a `childId` of `0` to get based on `interfaceId`.
Fixes #10
Closes #11 